### PR TITLE
Type should be lowercase on graphql Schema

### DIFF
--- a/templates/Schema.mustache
+++ b/templates/Schema.mustache
@@ -1,11 +1,11 @@
-Type Query {
+type Query {
   #
 }
 
-Type Mutation {
+type Mutation {
   #
 }
 
-Type {{name}} {
+type {{name}} {
   #
 }


### PR DESCRIPTION
Currently throws an error `GraphQLError: Syntax Error: Unexpected Name "Type"`