### PR TITLE
Added support for directives

### DIFF
--- a/commands/MakeDirectives.js
+++ b/commands/MakeDirectives.js
@@ -12,7 +12,7 @@ const Config = use('Config')
 const { join, sep } = require('path')
 const { Command } = require('@adonisjs/ace')
 
-class MakeResolvers extends Command {
+class MakeDirectives extends Command {
   /**
    * Command signature required by ace.
    *

--- a/commands/MakeDirectives.js
+++ b/commands/MakeDirectives.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * adonis-graphql
+ *
+ * @license MIT
+ * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
+ */
+
+const _ = require('lodash')
+const Config = use('Config')
+const { join, sep } = require('path')
+const { Command } = require('@adonisjs/ace')
+
+class MakeResolvers extends Command {
+  /**
+   * Command signature required by ace.
+   *
+   * @return {string}
+   */
+  static get signature () {
+    return `make:gdirectives { name: Name of directives }`
+  }
+
+  /**
+   * Command description.
+   *
+   * @return {string}
+   */
+  static get description () {
+    return 'Make a new GraphQL Directives'
+  }
+
+  /**
+   * Method called when command is executed. This method will
+   * require all files from the migrations directory
+   * and execute all pending schema files.
+   *
+   * @param  {object}   args
+   *
+   * @return {void}
+   */
+  async handle ({ name }) {
+    const templatePath = join(__dirname, '../templates/Directives.mustache')
+    const filePath = join(Config.get('graphql.directives'), _.upperFirst(_.camelCase(name))) + '.js'
+    const templateContent = await this.readFile(templatePath, 'utf-8')
+
+    await this.generateFile(filePath, templateContent, { name })
+
+    const createdFile = filePath.replace(process.cwd(), '').replace(sep, '')
+    console.log(`${this.icon('success')} ${this.chalk.green('create')}  ${createdFile}`)
+  }
+}
+
+module.exports = MakeSchema

--- a/commands/MakeDirectives.js
+++ b/commands/MakeDirectives.js
@@ -52,4 +52,4 @@ class MakeDirectives extends Command {
   }
 }
 
-module.exports = MakeSchema
+module.exports = MakeDirectives

--- a/config/graphql.js
+++ b/config/graphql.js
@@ -6,5 +6,7 @@ module.exports = {
 
   schema: join(__dirname, '../app/Schema'),
 
-  resolvers: join(__dirname, '../app/Resolvers')
+  resolvers: join(__dirname, '../app/Resolvers'),
+  
+  directives: join(__dirname, '../app/Directives')
 }

--- a/providers/GraphQLProvider.js
+++ b/providers/GraphQLProvider.js
@@ -60,6 +60,7 @@ class GraphQLProvider extends ServiceProvider {
     const ace = require('@adonisjs/ace')
     ace.addCommand('GraphQL/Commands/Make:Schema')
     ace.addCommand('GraphQL/Commands/Make:Resolvers')
+    ace.addCommand('GraphQL/Commands/Make:Directives')
 
     this.$registerAlias()
   }

--- a/providers/GraphQLProvider.js
+++ b/providers/GraphQLProvider.js
@@ -21,6 +21,7 @@ class GraphQLProvider extends ServiceProvider {
   $registerCommands () {
     this.app.bind('GraphQL/Commands/Make:Schema', () => require('../commands/MakeSchema'))
     this.app.bind('GraphQL/Commands/Make:Resolvers', () => require('../commands/MakeResolvers'))
+    this.app.bind('GraphQL/Commands/Make:Directives', () => require('../commands/MakeDirectives'))
   }
 
   /**

--- a/templates/Directives.mustache
+++ b/templates/Directives.mustache
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = {
+  directive (next, src, args, context) {
+    return next().then((value) => {
+      // reutrn value
+    })
+  }
+}


### PR DESCRIPTION
Example:

```
'use stricts'
const GraphQLError = use('Adonis/Addons/GraphQLError')

module.exports = {
  async isAuthenticated (next, src, args, { auth }) {
    try {
      await auth.check()
      return next()
    } catch (error) {
      throw new GraphQLError('User has to be authenticated')
    }
  }
}
```

There can be issues I started to learn GraphQL yesterday.