### PR TITLE
Wrap fileLoader calls in try/catch to print better stack traces

### DIFF
--- a/src/Server/index.js
+++ b/src/Server/index.js
@@ -13,10 +13,15 @@ const { fileLoader, mergeTypes, mergeResolvers } = require('merge-graphql-schema
 
 class GraphQLServer {
   constructor (config) {
-    const typeDefs = mergeTypes(fileLoader(config.get('graphql.schema'), { recursive: true }))
-    const resolvers = mergeResolvers(fileLoader(config.get('graphql.resolvers')))
+    try {
+      const typeDefs = mergeTypes(fileLoader(config.get('graphql.schema'), { recursive: true }))
+      const resolvers = mergeResolvers(fileLoader(config.get('graphql.resolvers')))
 
-    this.$schema = makeExecutableSchema({ typeDefs, resolvers })
+      this.$schema = makeExecutableSchema({ typeDefs, resolvers })
+    } catch (e) {
+      console.log(e.stack)
+      throw e
+    }
 
     this.$options = config.get('graphql.options')
   }


### PR DESCRIPTION
Wrap fileLoader calls in try/catch so that in the event of a syntax error we can print a stack trace pointing to the offending file (see bug #16).